### PR TITLE
removing requirejs dependency from shim and sham

### DIFF
--- a/darwin
+++ b/darwin
@@ -1,0 +1,1 @@
+removing requirejs from es5-shim 

--- a/darwin
+++ b/darwin
@@ -1,1 +1,0 @@
-removing requirejs from es5-shim 

--- a/package.json
+++ b/package.json
@@ -6,9 +6,8 @@
     "url": "https://github.com/skyglobal/polyfil.git"
   },
   "dependencies": {
-    "es5-shim": "^4.1.1",
-    "es5-shim-sham": "0.0.1"
-  },
+    "es5-shim": "git+ssh://git@github.com/sky-uk/es5-shim"
+    },
   "devDependencies": {
     "component-helper": "~0.8.8",
     "findup-sync": "^0.2.1",


### PR DESCRIPTION
In order to avoid requireJS throwing an anonymous module definition exception , we needed to remove it from both shim and sham files.

This fixes this: https://github.com/sky-uk/sky-tags/issues/139

Nilesh & Antonio
